### PR TITLE
adding glossary back

### DIFF
--- a/modules/getting-started/nav.adoc
+++ b/modules/getting-started/nav.adoc
@@ -2,3 +2,4 @@
 * xref:general:ROOT:index.adoc[MuleSoft Documentation]
 * xref:check-published-api-specs.adoc[Check Published RAML API Specifications Starting January 10, 2019]
 * xref:api-lifecycle-overview.adoc[About Crowd Release Availability and Changes]
+* xref:glossary.adoc[Anypoint Platform Glossary]

--- a/modules/getting-started/pages/glossary.adoc
+++ b/modules/getting-started/pages/glossary.adoc
@@ -5,7 +5,7 @@ endif::[]
 
 Authorized short versions of some product names are presented in parentheses, for example: Anypoint Design Center (Design Center).
 
-= A
+== A
 access management::
 Anypoint Platform features that help you manage your account and configure access and permissions within your organization. A REST API provides programmatic control of access-related resources.​
 
@@ -75,7 +75,7 @@ application network::
 A network that connects applications, data, and devices through APIs.
 The network allows consumers from other parts of the business to discover and use assets.
 
-= C
+== C
 
 component::
 1. In Anypoint Platform, a POJO, Spring bean, Java bean, or a script such as Groovy, Ruby, Python, or JavaScript that contains the business logic for processing messages passing through Mule. These components typically take the whole message - or just the payload - as input. They return an object that becomes the message payload for the next element in the message processor chain.
@@ -97,7 +97,7 @@ A class that parses a configuration file. The default configuration builder is t
 control plane::
 Programmatic access to network administration. In Anypoint Platform, the control plane consists of Anypoint Design Center, Anypoint Management Center, and Anypoint Exchange.
 
-= D
+== D
 dataloader.io::
 The data loader for Salesforce.
 
@@ -107,22 +107,22 @@ A feature of Anypoint Studio that uses message metadata to facilitate applicatio
 DataWeave::
 The DataWeave Language queries and transforms data for integrations.
 
-= E
+== E
 
 Edge::
 Anypoint Security feature to help you manage edge security.
 
-= F
+== F
 
 flow::
 A simple, flexible mechanism that enables orchestration of services using the sophisticated message flow capabilities of Mule® runtime engine.   Also referred to as service orchestration.
 
-= H
+== H
 
 hybrid deployment::
 Deploying a Mule Application via the cloud console of the Anypoint Runtime Manager to an on-premises server that hosts Mule runtime engine. This deployment is hybrid in the sense that the hosting of your application is on-premises, while application management is in the cloud.
 
-= M
+== M
 message filter::
 A message processor that controls whether a message is processed by a filter.
 
@@ -130,7 +130,7 @@ message processor::
 A basic building block used to construct flows. A message processor controls how messages are sent and received within a flow. 
 
 message receiver::
-A Java class used by a connector to read the incoming data, package it as a message, and passes it to a service component’s inbound router. The message receiver can use a transformer if necessary to convert the data.
+A Java class used by a connector to read the incoming data, package it as a message, and pass it to a service component’s inbound router. The message receiver can use a transformer if necessary to convert the data.
 
 mocking service::
 Provides a public URI to test or explore an API.  
@@ -147,12 +147,12 @@ The enterprise version of Mule, available for 30-day trial download. The Enterpr
 Mule® runtime engine (Mule® or Mule)::
 Java-based integration runtime engine for Anypoint Platform. 
 
-= O
+== O
 
 organization::
 The container for everything in your Anypoint Platform account. 
 
-= P
+== P
 
 Pivotal Cloud Foundry::
 A cloud computing platform as a service (PaaS) provided by the company Pivotal. Anypoint Platform integrates with Pivotal Cloud Foundry, allowing you to deploy Mule applications to dynamically created virtual machines on your own private network. See deployment strategies. Previously referred to as PCF.
@@ -160,7 +160,7 @@ A cloud computing platform as a service (PaaS) provided by the company Pivotal. 
 policy::
 An object that controls authentication, access, consumption rates, and service level access (SLA) to API resources. Anypoint Platform provides both preconfigured and tools to create custom policies.
 
-= R
+== R
 
 RAML®::
 RESTful API Modeling Language (RAML) provides a specification language that you use to define an API.
@@ -171,12 +171,12 @@ The Runtime Manager agent mediates communication between the Anypoint Runtime Ma
 runtime plane::
 The contract between the control plane and data plane for runtime control. In Anypoint Platform, the runtime plane consists of Mule runtime engine and runtime services managed with tools like Anypoint Runtime Fabric.
 
-= S
+== S
 
 secrets manager::
 A features that stores and controls access to private keys, passwords, certificates, and other secrets.
 
-= T
+== T
 
 tokenization::
 Substituting a non-sensitive equivalent for a sensitive data element.
@@ -187,12 +187,12 @@ A feature that transforms message payloads (data) to and from different types, s
 transport::
 A feature that carries messages on a specific messaging protocol, such as FTP. Several connectors incorporate transports.
 
-= U
+== U
 
 universal message object (UMO)::
 Obsolete name for service component. UMO is still visible in some MuleSoft APIs.
 
-= X
+== X
 
 XA transaction:: 
 A transaction that enlists multiple managed resources and provides guaranteed reliability. Mule runtime engine also supports multi-resource transactions that are not XA transactions. These transactions do not have guaranteed reliability.

--- a/modules/getting-started/pages/glossary.adoc
+++ b/modules/getting-started/pages/glossary.adoc
@@ -7,7 +7,7 @@ Authorized short versions of some product names are presented in parentheses, fo
 
 = A
 access management::
-Anypoint Platform features that help you manage your account, configure access and permissions within your organization. A REST API provides programmatic control of access-related resources.​
+Anypoint Platform features that help you manage your account and configure access and permissions within your organization. A REST API provides programmatic control of access-related resources.​
 
 agent::
 A service, such as the Runtime Manager agent, that is used by or associated with Mule but is not a Mule-managed service component. An agent is registered with the Anypoint Runtime Manager and has the same lifecycle as the corresponding Mule instance, so you can initialize and destroy resources when the Mule instance starts or stops. 
@@ -19,7 +19,7 @@ Anypoint Design Center’s API designer (API designer)::
 Web-based graphical environment for designing, documenting, and testing APIs.
 
 Anypoint Exchange (Exchange)::
-MuleSoft repository for connectors, templates, examples and RAML APIs. Discover and use proven assets built by the MuleSoft ecosystem. You can create your own Exchange and add assets to it for collaboration and sharing among a group.
+MuleSoft repository for connectors, templates, examples, and RAML APIs. Discover and use proven assets built by the MuleSoft ecosystem. You can create your own Exchange and add assets to it for collaboration and sharing among a group.
 
 Anypoint Management Center (Management Center)::
 A single web interface to administer Anypoint Platform, both on-premises and in the cloud. Manage APIs and users, analyze traffic, monitor SLAs, and troubleshoot underlying integration flows.
@@ -31,7 +31,7 @@ Anypoint Object Store v2::
 Storage for data and states across batch processes and Mule components from within a single application.
 
 Anypoint Partner Manager v2::
-The web-based user interface for partner configuration, document flow  and transaction monitoring.
+The web-based user interface for partner configuration, document flow,  and transaction monitoring.
 
 Anypoint Platform™::
 MuleSoft’s product to design, build, and manage APIs and integrations.
@@ -43,7 +43,7 @@ Anypoint Runtime Fabric::
 A container service that automates the configuration, coordination, and management (orchestration), and deployment of your Mule applications and gateways. Runtime Fabric runs on customer-managed infrastructure on AWS, Azure, virtual machines (VMs) or bare-metal servers.
 
 Anypoint Runtime Manager (Runtime Manager)::
-The Runtime Manager is a console where you to deploy and manage applications built with any Mule. From the console, deploy to servers in the cloud (currently handled by CloudHub) or on premises. Access the console in Anypoint Platform or download it as a standalone program that runs in a local server. Previously referred to as ARM.
+A console where you deploy and manage applications built with any Mule. Deploy to servers in the cloud (currently handled by CloudHub) or on premises. s the console in Anypoint Platform or download it as a standalone program that runs in a local server. Previously referred to as ARM.
 
 Anypoint Security::
 Layers of features that secure your application network.
@@ -133,19 +133,19 @@ message receiver::
 A Java class used by a connector to read the incoming data, package it as a message, and passes it to a service component’s inbound router. The message receiver can use a transformer if necessary to convert the data.
 
 mocking service::
-Provides a public URI to an API being designed. Exercising the URI returns the responses defined in the API specification for testing or exploring an API.
+Provides a public URI to test or explore an API.  
 
 Mule® application::
 An app that is configured to run in Mule runtime engine.
 
 module::
-A construct that groups together components. Modules add flexibility to your apps by allowing you to aggregate values, compress data, use Java features, and use extra features for processing JSON.
+A group of components. Modules add flexibility to your apps by allowing you to aggregate values, compress data, use Java features, and process JSON.
 
 Mule Enterprise Edition (EE)::
-The enterprise version of Mule, available for 30-day trial download. The Enterprise Edition includes full development cycles, testing, technical support, maintenance releases and hot fixes, and management and monitoring tools from MuleSoft. If you are deploying Mule in a mission-critical environment, want to ensure that you always have a stable, high-quality release, and want additional tools for managing and monitoring your deployment, you should purchase a subscription to Mule Enterprise Edition.
+The enterprise version of Mule, available for 30-day trial download. The Enterprise Edition includes full development cycles, testing, technical support, maintenance releases and hot fixes, and management and monitoring tools from MuleSoft.
 
 Mule® runtime engine (Mule® or Mule)::
-Java-based integration runtime engine for Anypoint Platform. uses a staged event-driven architecture (SEDA) to enqueue messages and process them inside of flows in separate stages. Mule is the engine for Anypoint Platform™ and the only runtime that combines data and application integration across legacy systems, SaaS applications, and APIs.
+Java-based integration runtime engine for Anypoint Platform. 
 
 = O
 
@@ -163,7 +163,7 @@ An object that controls authentication, access, consumption rates, and service l
 = R
 
 RAML®::
-RESTful API Modeling Language (RAML) provides a specification language that you can use to define an API.
+RESTful API Modeling Language (RAML) provides a specification language that you use to define an API.
 
 Runtime Manager agent::
 The Runtime Manager agent mediates communication between the Anypoint Runtime Manager console and the Mule instances running on servers. Using the Mule agent, you can monitor and control Mule servers. Previously referred to as Runtime agent.
@@ -174,7 +174,7 @@ The contract between the control plane and data plane for runtime control. In An
 = S
 
 secrets manager::
-Construct to store and control access to private keys, passwords, certificates, and other secrets.
+A features that stores and controls access to private keys, passwords, certificates, and other secrets.
 
 = T
 
@@ -182,20 +182,15 @@ tokenization::
 Substituting a non-sensitive equivalent for a sensitive data element.
 
 transformer::
-A construct that transforms message payloads (data) to and from different types, such as the XSLT Transformer. Transformations can also be defined using DataWeave.
+A feature that transforms message payloads (data) to and from different types, such as the XSLT Transformer. Transformations can also be defined using DataWeave.
 
 transport::
-A construct that handles and carries messages on a specific messaging protocol, such as FTP. Several connectors incorporate transports.
+A feature that carries messages on a specific messaging protocol, such as FTP. Several connectors incorporate transports.
 
 = U
 
 universal message object (UMO)::
 Obsolete name for service component. UMO is still visible in some MuleSoft APIs.
-
-= V
-
-Virtual Private Cloud::
-A virtual, private, and isolated network segment in the cloud that hosts CloudHub instances of Mule (CloudHub workers). Previously referred to as VPC.
 
 = X
 

--- a/modules/getting-started/pages/glossary.adoc
+++ b/modules/getting-started/pages/glossary.adoc
@@ -1,0 +1,203 @@
+= Anypoint Platform Glossary
+ifndef::env-site,env-github[]
+include::_attributes.adoc[]
+endif::[]
+
+Authorized short versions of some product names are presented in parentheses, for example: Anypoint Design Center (Design Center).
+
+= A
+access management::
+Anypoint Platform features that help you manage your account, configure access and permissions within your organization. A REST API provides programmatic control of access-related resources.​
+
+agent::
+A service, such as the Runtime Manager agent, that is used by or associated with Mule but is not a Mule-managed service component. An agent is registered with the Anypoint Runtime Manager and has the same lifecycle as the corresponding Mule instance, so you can initialize and destroy resources when the Mule instance starts or stops. 
+
+Anypoint Design Center (Design Center)::
+A cloud-based development environment for Mule runtime engine (Mule) applications and API definitions.
+
+Anypoint Design Center’s API designer (API designer)::
+Web-based graphical environment for designing, documenting, and testing APIs.
+
+Anypoint Exchange (Exchange)::
+MuleSoft repository for connectors, templates, examples and RAML APIs. Discover and use proven assets built by the MuleSoft ecosystem. You can create your own Exchange and add assets to it for collaboration and sharing among a group.
+
+Anypoint Management Center (Management Center)::
+A single web interface to administer Anypoint Platform, both on-premises and in the cloud. Manage APIs and users, analyze traffic, monitor SLAs, and troubleshoot underlying integration flows.
+
+Anypoint MQ (messaging queue)::
+Enterprise-class cloud messaging that is fully integrated with Anypoint Platform.
+
+Anypoint Object Store v2::
+Storage for data and states across batch processes and Mule components from within a single application.
+
+Anypoint Partner Manager v2::
+The web-based user interface for partner configuration, document flow  and transaction monitoring.
+
+Anypoint Platform™::
+MuleSoft’s product to design, build, and manage APIs and integrations.
+
+Anypoint Platform Private Cloud Edition::
+A special packaging of the Anypoint Platform is available for running on your own local servers. This implementation runs on Docker and Kubernetes, and is also compatible with Pivotal Cloud Foundry, and  includes versions of Runtime Manager, API Manager and Anypoint Exchange. 
+
+Anypoint Runtime Fabric::
+A container service that automates the configuration, coordination, and management (orchestration), and deployment of your Mule applications and gateways. Runtime Fabric runs on customer-managed infrastructure on AWS, Azure, virtual machines (VMs) or bare-metal servers.
+
+Anypoint Runtime Manager (Runtime Manager)::
+The Runtime Manager is a console where you to deploy and manage applications built with any Mule. From the console, deploy to servers in the cloud (currently handled by CloudHub) or on premises. Access the console in Anypoint Platform or download it as a standalone program that runs in a local server. Previously referred to as ARM.
+
+Anypoint Security::
+Layers of features that secure your application network.
+These layers work together to protect both the application network and the network’s individual nodes by controlling access to APIs, enforcing policies, and proxying all inbound or outbound traffic to mitigate external threats and attacks.
+
+Anypoint Studio (Studio)::
+An integrated development environment with visual and XML editors to design, debug and test Mule applications. Using the visual interface, you can drag and drop connectors, loggers, flow control, routers, data transformers, and much more to the design canvas. You can also debug and test from the Studio user interface. 
+
+Anypoint Virtual Private Cloud (Anypoint VPC)::
+Features that help you create a virtual, private, and isolated network segment in the cloud to host your CloudHub instances of Mule (CloudHub workers).
+
+Anypoint Visualizer::
+Dynamically generated views of different aspects of an application network graph. 
+
+API Manager::
+Part of the Anypoint Platform that allows you to design and manage your APIs. It includes the [API Designer], which allows you to write a [RAML] definition of your API. It also includes tools to monitor usage metrics, apply [policies] and to expose interactive documentation through an [API Portal]
+
+API Portal::
+An access point where you can present an API to attract users. How is this different from a private Exchange portal?
+
+API proxy::
+A feature of Anypoint API Manager that supplies a layer of protection against attacks on MuleSoft APIs.
+Manage APIs with the UI instead of having to write code. Formerly called API Gateway.
+
+APIkit::
+APIkit is a tool for building Mule REST or SOAP APIs. Formerly called SOAPkit.
+
+application network::
+A network that connects applications, data, and devices through APIs.
+The network allows consumers from other parts of the business to discover and use assets.
+
+= C
+
+component::
+1. In Anypoint Platform, a POJO, Spring bean, Java bean, or a script such as Groovy, Ruby, Python, or JavaScript that contains the business logic for processing messages passing through Mule. These components typically take the whole message - or just the payload - as input. They return an object that becomes the message payload for the next element in the message processor chain.
+
+2. Generically, an architecturally specific portion of a software package.
+
+connector::
+A self-contained component that allows you to integrate Mule applications with the APIs of other, external applications, such as SalesForce, CMIS, and Twitter. A set of connectors is included in Mule version 4. Other connectors created by MuleSoft or third parties are available on Anypoint Exchange.
+
+CloudHub::
+Integration platform as a service that lets you manage applications in the cloud. When deploying an application to the cloud through the Runtime Manager console, CloudHub is used in the background.
+
+clustering::
+Using a set of Mule instances that act as, and can be managed as, a unit. A cluster is a virtual server composed of multiple nodes. You can manage cluster instances from the cloud.
+
+configuration builder:: 
+A class that parses a configuration file. The default configuration builder is the `org.mule.config.MuleXmlConfigurationBuilder` class, which parses a Mule XML configuration file.
+
+control plane::
+Programmatic access to network administration. In Anypoint Platform, the control plane consists of Anypoint Design Center, Anypoint Management Center, and Anypoint Exchange.
+
+= D
+dataloader.io::
+The data loader for Salesforce.
+
+DataSense::
+A feature of Anypoint Studio that uses message metadata to facilitate application design. With DataSense, Anypoint Studio proactively acquires information such as data type and structure, in order to prescribe how to accurately map or use this data in your application.
+
+DataWeave::
+The DataWeave Language queries and transforms data for integrations.
+
+= E
+
+Edge::
+Anypoint Security feature to help you manage edge security.
+
+= F
+
+flow::
+A simple, flexible mechanism that enables orchestration of services using the sophisticated message flow capabilities of Mule® runtime engine.   Also referred to as service orchestration.
+
+= H
+
+hybrid deployment::
+Deploying a Mule Application via the cloud console of the Anypoint Runtime Manager to an on-premises server that hosts Mule runtime engine. This deployment is hybrid in the sense that the hosting of your application is on-premises, while application management is in the cloud.
+
+= M
+message filter::
+A message processor that controls whether a message is processed by a filter.
+
+message processor::
+A basic building block used to construct flows. A message processor controls how messages are sent and received within a flow. 
+
+message receiver::
+A Java class used by a connector to read the incoming data, package it as a message, and passes it to a service component’s inbound router. The message receiver can use a transformer if necessary to convert the data.
+
+mocking service::
+Provides a public URI to an API being designed. Exercising the URI returns the responses defined in the API specification for testing or exploring an API.
+
+Mule® application::
+An app that is configured to run in Mule runtime engine.
+
+module::
+A construct that groups together components. Modules add flexibility to your apps by allowing you to aggregate values, compress data, use Java features, and use extra features for processing JSON.
+
+Mule Enterprise Edition (EE)::
+The enterprise version of Mule, available for 30-day trial download. The Enterprise Edition includes full development cycles, testing, technical support, maintenance releases and hot fixes, and management and monitoring tools from MuleSoft. If you are deploying Mule in a mission-critical environment, want to ensure that you always have a stable, high-quality release, and want additional tools for managing and monitoring your deployment, you should purchase a subscription to Mule Enterprise Edition.
+
+Mule® runtime engine (Mule® or Mule)::
+Java-based integration runtime engine for Anypoint Platform. uses a staged event-driven architecture (SEDA) to enqueue messages and process them inside of flows in separate stages. Mule is the engine for Anypoint Platform™ and the only runtime that combines data and application integration across legacy systems, SaaS applications, and APIs.
+
+= O
+
+organization::
+The container for everything in your Anypoint Platform account. 
+
+= P
+
+Pivotal Cloud Foundry::
+A cloud computing platform as a service (PaaS) provided by the company Pivotal. Anypoint Platform integrates with Pivotal Cloud Foundry, allowing you to deploy Mule applications to dynamically created virtual machines on your own private network. See deployment strategies. Previously referred to as PCF.
+
+policy::
+An object that controls authentication, access, consumption rates, and service level access (SLA) to API resources. Anypoint Platform provides both preconfigured and tools to create custom policies.
+
+= R
+
+RAML®::
+RESTful API Modeling Language (RAML) provides a specification language that you can use to define an API.
+
+Runtime Manager agent::
+The Runtime Manager agent mediates communication between the Anypoint Runtime Manager console and the Mule instances running on servers. Using the Mule agent, you can monitor and control Mule servers. Previously referred to as Runtime agent.
+
+runtime plane::
+The contract between the control plane and data plane for runtime control. In Anypoint Platform, the runtime plane consists of Mule runtime engine and runtime services managed with tools like Anypoint Runtime Fabric.
+
+= S
+
+secrets manager::
+Construct to store and control access to private keys, passwords, certificates, and other secrets.
+
+= T
+
+tokenization::
+Substituting a non-sensitive equivalent for a sensitive data element.
+
+transformer::
+A construct that transforms message payloads (data) to and from different types, such as the XSLT Transformer. Transformations can also be defined using DataWeave.
+
+transport::
+A construct that handles and carries messages on a specific messaging protocol, such as FTP. Several connectors incorporate transports.
+
+= U
+
+universal message object (UMO)::
+Obsolete name for service component. UMO is still visible in some MuleSoft APIs.
+
+= V
+
+Virtual Private Cloud::
+A virtual, private, and isolated network segment in the cloud that hosts CloudHub instances of Mule (CloudHub workers). Previously referred to as VPC.
+
+= X
+
+XA transaction:: 
+A transaction that enlists multiple managed resources and provides guaranteed reliability. Mule runtime engine also supports multi-resource transactions that are not XA transactions. These transactions do not have guaranteed reliability.


### PR DESCRIPTION
Adding a glossary: Will & Fer, when I tested this locally, the glossary.html was created and looked correct on my local machine, and the left nav showed the link for glossary, but when I clicked the link in my local build, I got the Page Not Found error. Could you look at this and see if I've done something wrong? 