### PR TITLE
remove links to removed topic

### DIFF
--- a/modules/getting-started/pages/implement-and-test.adoc
+++ b/modules/getting-started/pages/implement-and-test.adoc
@@ -97,4 +97,4 @@ The result of every test is shown in the MUnit View in Anypoint Studio.
 * xref:3.x@apikit::apikit-basic-anatomy.adoc[APIkit Router for Mule 3]
 * https://docs.archive.mulesoft.com/munit/v/1.2/[MUnit]
 * https://docs.archive.mulesoft.com/munit/v/1.2/munit-suite[MUnit test suite]
-* xref:mule-runtime::migration-munit[Munit Migration for Mule 4]
+* xref:mule-runtime::migration-munit.adoc[Munit Migration for Mule 4]

--- a/modules/getting-started/pages/implement-and-test.adoc
+++ b/modules/getting-started/pages/implement-and-test.adoc
@@ -97,4 +97,4 @@ The result of every test is shown in the MUnit View in Anypoint Studio.
 * xref:3.x@apikit::apikit-basic-anatomy.adoc[APIkit Router for Mule 3]
 * https://docs.archive.mulesoft.com/munit/v/1.2/[MUnit]
 * https://docs.archive.mulesoft.com/munit/v/1.2/munit-suite[MUnit test suite]
-* mule-runtime::migration-munit[Munit Migration for Mule 4]
+* xref:mule-runtime::migration-munit[Munit Migration for Mule 4]

--- a/modules/getting-started/pages/implement-and-test.adoc
+++ b/modules/getting-started/pages/implement-and-test.adoc
@@ -93,8 +93,8 @@ The result of every test is shown in the MUnit View in Anypoint Studio.
 
 == See Also
 
-* xref:sync-api-apisync.adoc[Sync an API]
-* xref:3.8@mule-runtime::reference-exception-strategy.adoc[Reference Exception Strategy]
-* xref:3.x@apikit::apikit-basic-anatomy.adoc[APIkit Router]
+* xref:3.8@mule-runtime::reference-exception-strategy.adoc[Reference Exception Strategy for Mule 3]
+* xref:3.x@apikit::apikit-basic-anatomy.adoc[APIkit Router for Mule 3]
 * https://docs.archive.mulesoft.com/munit/v/1.2/[MUnit]
-* https://docs.archive.mulesoft.com/munit/v/1.2/munit-suite[MUnit test suite].
+* https://docs.archive.mulesoft.com/munit/v/1.2/munit-suite[MUnit test suite]
+* mule-runtime::migration-munit[Munit Migration for Mule 4]

--- a/modules/getting-started/pages/index.adoc
+++ b/modules/getting-started/pages/index.adoc
@@ -14,7 +14,7 @@ If you have prior knowledge of APIs, you may want to know about xref:mule-runtim
 
 . Find out xref:design-an-api.adoc[How to Design an API].
 . After designing the API, learn xref:implement-and-test.adoc[How to Implement and Test an API].
-. To bring your API to your organization or a larger audience, see xref:sync-api-apisync.adoc[How to Sync an API to the Platform].
+. To share an API, see xref:exchange::about-sharing-assets.adoc[Share Assets]
 
 == Getting Started with Mule Applications
 


### PR DESCRIPTION
Not sure when we'll delete these topics, so updating them for now and removing link to the one topic I know we are removing now. Am building locally now to test links.