### PR TITLE
Standalone runtime support for PCE

### DIFF
--- a/modules/ROOT/pages/intro-platform-hosting.adoc
+++ b/modules/ROOT/pages/intro-platform-hosting.adoc
@@ -141,6 +141,6 @@ The following table lists which runtime plane options are supported in each cont
 |===
 | Runtime Plane | US Cloud | EU Cloud| Government Cloud | Anypoint Platform PCE
 | CloudHub | Y | Y | Y | N
-| Standalone runtimes | Y | Y | N | N
+| Standalone runtimes | Y | Y | N | Y
 | Runtime Fabric | Y | Y | N | N
 |===


### PR DESCRIPTION
Corrected PCE to show "Y" for standalone runtime support
(cc @bricker386)