### PR TITLE
Update Anypoint Security Components

### DIFF
--- a/modules/ROOT/pages/intro-platform-hosting.adoc
+++ b/modules/ROOT/pages/intro-platform-hosting.adoc
@@ -74,8 +74,8 @@ Not all Anypoint Platform components are supported in all cloud environments. Th
 | Anypoint Monitoring | Y | Y | N | Y
 | Secrets manager | Y | Y | N | N
 | Anypoint Visualizer | Y | Y | N | Y
-| Anypoint Security edge policies | Y | Y | N | N
-| Anypoint Security tokenization | Y | Y | N | N
+| Anypoint Security edge policies | N | N | N | N
+| Anypoint Security tokenization | N | N | N | N
 | Anypoint DataGraph | Y | Y | N | N
 | CloudHub runtimes | Y | Y | Y | N
 | Runtime Fabric | Y | Y | N | N


### PR DESCRIPTION
Anypoint Security Edge Policies and Anypoint Security Tokenization are marked as included in US/EU Cloud, but in reality, they can only work with Runtime Fabric. It is not available for Cloudhub deployments.