### PR TITLE
W-11098233: Links to the platform should not have 'www.'

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -17,7 +17,7 @@ Anypoint Platform makes it easy to discover, create, and manage APIs in a modula
 
 The APIs you build in Anypoint Platform to integrate applications and services are reusable and include enterprise-level security.
 You can discover these APIs, as well as connectors, samples, and templates, in
-https://www.anypoint.mulesoft.com/exchange/[Exchange^].
+https://anypoint.mulesoft.com/exchange/[Exchange^].
 
 Exchange also provides RAML fragments, custom packages, videos, links to documentation, and other assets.
 


### PR DESCRIPTION
[W-11098233](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000wLRxMYAW/view): 
Based on the engineering feedback, we should update the links to the Anypoint platform to remove the `www.` section of the URL as it might not be fully supported.