### PR TITLE
[W-14565499] Remove homepage button from this repo and move to docs-site-ui

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -4,9 +4,6 @@
 :!sectids:
 ifndef::env-site[:imagesdir: ../images]
 
-[#cta]
-xref:api-led-overview.adoc[New to MuleSoft? Start here.]
-
 [#the-road]
 == The Road to Digital Transformation
 


### PR DESCRIPTION
Moving this button to the docs-site-ui repo as part of the effort to Salesforce-ify our styles. Context in the accompanying PR here:
https://github.com/mulesoft/docs-site-ui/pull/662