### PR TITLE
[W-19620336] Update paths for learning map images

### DIFF
--- a/modules/ROOT/pages/learning-map-api-management.adoc
+++ b/modules/ROOT/pages/learning-map-api-management.adoc
@@ -7,7 +7,7 @@ The end-to-end API lifecycle journey for API management consists of various task
 
 [.lm-table, cols="1a,1a,1a", grid="none"]
 |===
-| image::../_/img/learning-map/lm_start.png[]
+| image::reuse::lm_start.png[]
 [.lm-bold]##What Is API Management?##
 
 API management is the process of creating, publishing, and overseeing application programming interfaces (APIs) in a secure and scalable environment.
@@ -16,7 +16,7 @@ API management helps ensure that APIs are reliable, secure, and easy to use, whi
 
 - https://www.mulesoft.com/api/management[Anypoint Platform API Management]
 
-| image::../_/img/learning-map/lm_explore_1.png[]
+| image::reuse::lm_explore_1.png[]
 [.lm-bold]##Design and Build##
 
 Implement APIs with any system.
@@ -30,7 +30,7 @@ Implement APIs with any system.
 - https://www.youtube.com/watch?v=GvsTSFjB4Gs[Build APIs]
 - https://trailhead.salesforce.com/content/learn/modules/mulesoft-anypoint-code-builder-quick-look[Anypoint Code Builder: Quick Look]
 
-| image::../_/img/learning-map/lm_analyze_1.png[]
+| image::reuse::lm_analyze_1.png[]
 [.lm-bold]##Discover##
 
 Enable your developer community to discover your APIs anywhere automatically along with relevant metadata and documentation.
@@ -43,7 +43,7 @@ Enable your developer community to discover your APIs anywhere automatically alo
 
 [.lm-table, cols="1a,1a,1a", grid="none"]
 |===
-| image::../_/img/learning-map/lm_test_1.png[]
+| image::reuse::lm_test_1.png[]
 [.lm-bold]##Govern##
 
 Ensure consistent API quality and security by applying governance rules to your APIs as part of the API lifecycle.
@@ -55,7 +55,7 @@ Ensure consistent API quality and security by applying governance rules to your 
 - https://www.youtube.com/watch?v=GuRNme2tLkw[Govern API Policy Instances for Developers]
 - https://trailhead.salesforce.com/content/learn/projects/govern-apis-using-anypoint-api-governance[Govern Your APIs Using API Governance]
 
-| image::../_/img/learning-map/lm_build_1.png[]
+| image::reuse::lm_build_1.png[]
 [.lm-bold]##Manage and Secure##
 
 Control and secure access to any API.
@@ -70,7 +70,7 @@ Control and secure access to any API.
 - https://www.youtube.com/watch?v=eguO1gO-rss[Product Spotlight: Flex Gateway]
 - https://www.youtube.com/watch?v=OUFadXZ0NjQ[Friends of Max Overview: Flex Gateway]
 
-| image::../_/img/learning-map/lm_audience_end_1.png[]
+| image::reuse::lm_audience_end_1.png[]
 [.lm-bold]##Engage##
 
 Create custom API portals to engage with your ecosystem of API consumers and producers.


### PR DESCRIPTION
Related to this PR which moves the learning map images to docs-reuse: https://github.com/mulesoft/docs-reuse/pull/60

Tested in local build and confirmed the images still display:

<img width="1487" height="277" alt="Screenshot 2025-09-15 at 3 18 27 PM" src="https://github.com/user-attachments/assets/6caea077-73b8-45d5-97db-ee7fb6455e7a" />
