### PR TITLE
[W-19565643] Update paths for learning map images

### DIFF
--- a/modules/ROOT/pages/learning-map-api-management.adoc
+++ b/modules/ROOT/pages/learning-map-api-management.adoc
@@ -7,7 +7,7 @@ The end-to-end API lifecycle journey for API management consists of various task
 
 [.lm-table, cols="1a,1a,1a", grid="none"]
 |===
-| image::../_/img/learning-map/lm_start.png[]
+| image::reuse::lm_start.png[]
 [.lm-bold]##What Is API Management?##
 
 API management is the process of creating, publishing, and overseeing application programming interfaces (APIs) in a secure and scalable environment.
@@ -16,7 +16,7 @@ API management helps ensure that APIs are reliable, secure, and easy to use, whi
 
 - https://www.mulesoft.com/api/management[Anypoint Platform API Management]
 
-| image::../_/img/learning-map/lm_explore_1.png[]
+| image::reuse::lm_explore_1.png[]
 [.lm-bold]##Design and Build##
 
 Implement APIs with any system.
@@ -30,7 +30,7 @@ Implement APIs with any system.
 - https://www.youtube.com/watch?v=GvsTSFjB4Gs[Build APIs]
 - https://trailhead.salesforce.com/content/learn/modules/mulesoft-anypoint-code-builder-quick-look[Anypoint Code Builder: Quick Look]
 
-| image::../_/img/learning-map/lm_analyze_1.png[]
+| image::reuse::lm_analyze_1.png[]
 [.lm-bold]##Discover##
 
 Enable your developer community to discover your APIs anywhere automatically along with relevant metadata and documentation.
@@ -43,7 +43,7 @@ Enable your developer community to discover your APIs anywhere automatically alo
 
 [.lm-table, cols="1a,1a,1a", grid="none"]
 |===
-| image::../_/img/learning-map/lm_test_1.png[]
+| image::reuse::lm_test_1.png[]
 [.lm-bold]##Govern##
 
 Ensure consistent API quality and security by applying governance rules to your APIs as part of the API lifecycle.
@@ -55,7 +55,7 @@ Ensure consistent API quality and security by applying governance rules to your 
 - https://www.youtube.com/watch?v=GuRNme2tLkw[Govern API Policy Instances for Developers]
 - https://trailhead.salesforce.com/content/learn/projects/govern-apis-using-anypoint-api-governance[Govern Your APIs Using API Governance]
 
-| image::../_/img/learning-map/lm_build_1.png[]
+| image::reuse::lm_build_1.png[]
 [.lm-bold]##Manage and Secure##
 
 Control and secure access to any API.
@@ -70,7 +70,7 @@ Control and secure access to any API.
 - https://www.youtube.com/watch?v=eguO1gO-rss[Product Spotlight: Flex Gateway]
 - https://www.youtube.com/watch?v=OUFadXZ0NjQ[Friends of Max Overview: Flex Gateway]
 
-| image::../_/img/learning-map/lm_audience_end_1.png[]
+| image::reuse::lm_audience_end_1.png[]
 [.lm-bold]##Engage##
 
 Create custom API portals to engage with your ecosystem of API consumers and producers.

--- a/modules/ROOT/pages/learning-map-mulesoft-ai.adoc
+++ b/modules/ROOT/pages/learning-map-mulesoft-ai.adoc
@@ -7,7 +7,7 @@ The end-to-end AI journey for MuleSoft AI consists of various tasks, each with l
 
 [.lm-table, cols="1a,1a,1a", grid="none"]
 |===
-| image::../_/img/learning-map/lm_start.png[]
+| image::reuse::lm_start.png[]
 [.lm-bold]##Learn About MuleSoft AI##
 
 MuleSoft AI is a set of capabilities for building, orchestrating, governing, deploying, and observing AI agents and agent networks across your enterprise.
@@ -16,7 +16,7 @@ MuleSoft AI is a set of capabilities for building, orchestrating, governing, dep
 - https://docs.mulesoft.com[Transform Your Business with AI]
 - https://www.mulesoft.com/platform/[Enable Agent Actionability with MuleSoft AI]
 
-| image::../_/img/learning-map/lm_explore_1.png[]
+| image::reuse::lm_explore_1.png[]
 [.lm-bold]##Design and Orchestrate Agents##
 
 Design and coordinate AI agents using a declarative approach that promotes reuse, governance, and observability.
@@ -30,7 +30,7 @@ Design and coordinate AI agents using a declarative approach that promotes reuse
 - xref:monitoring::index.adoc[Monitor and Troubleshoot Your Agent Network]
 - xref:anypoint-code-builder::index.adoc[Deploy Your Agent Network]
 - https://videos.mulesoft.com/watch/wgZ5WuV6VgDbyK3bFKV2RJ[Orchestrate Your Agents]
-| image::../_/img/learning-map/lm_analyze_1.png[]
+| image::reuse::lm_analyze_1.png[]
 [.lm-bold]##Get Started##
 
 Kick off your agentic journey with quickstarts and templates.
@@ -42,7 +42,7 @@ Kick off your agentic journey with quickstarts and templates.
 
 [.lm-table, cols="1a,1a,1a", grid="none"]
 |===
-| image::../_/img/learning-map/lm_build_1.png[]
+| image::reuse::lm_build_1.png[]
 [.lm-bold]##Develop with AI-Powered Tools##
 
 Accelerate integration and agent development with AI using Anypoint Code Builder, MuleSoft connectors, and other tools.
@@ -59,7 +59,7 @@ Accelerate integration and agent development with AI using Anypoint Code Builder
 - xref:mulesoft-ai-chain-connector::index.adoc[Develop with MuleSoft AI Chain Connector]
 - xref:inference-connector::index.adoc[Develop with MuleSoft Inference Connector]
 
-| image::../_/img/learning-map/lm_analyze_1.png[]
+| image::reuse::lm_analyze_1.png[]
 [.lm-bold]##Observe and Gain Actionable Insights##
 
 Use Integration Intelligence for advanced monitoring, analysis, troubleshooting, and insights across agentic workloads and integrations.
@@ -70,7 +70,7 @@ Use Integration Intelligence for advanced monitoring, analysis, troubleshooting,
 - https://docs.mulesoft.com/[Use Metrics and Alerts]
 - https://docs.mulesoft.com/[View Logs and Traces]
 
-| image::../_/img/learning-map/lm_audience_end_1.png[]
+| image::reuse::lm_audience_end_1.png[]
 [.lm-bold]##Govern and Secure Your Agents##
 
 Apply policies and secure agent network traffic.


### PR DESCRIPTION
Related to this PR which moves the learning map images to docs-reuse: https://github.com/mulesoft/docs-reuse/pull/60
Updated the other learning map here: https://github.com/mulesoft/docs-general/pull/352