### PR TITLE
[W-21220554] Temporary: Remove page alias which points to existing page

### DIFF
--- a/modules/ROOT/pages/learning-map-agent-fabric.adoc
+++ b/modules/ROOT/pages/learning-map-agent-fabric.adoc
@@ -1,5 +1,4 @@
 = Get Started with Agent Fabric
-:page-aliases: agent-fabric::agent-fabric-get-started.adoc, agent-fabric::index.adoc
 :page-article-style: learning-map
 
 MuleSoft Agent Fabric helps you turn your agent sprawl into a governed and highly coordinated, intelligent network. 


### PR DESCRIPTION
The `agent-fabric::index.adoc` page still exists, so listing it as a page alias is causing internal builds to break. This only affects one internal beta site which is still pointing to the agent-fabric repo. I'm reaching out to the writer that owns it to see if they're all right with removing it. 

Until then, removing the alias to fix the error. Tested by pointing the broken `beta-exchange-scanners-ga.yml` site to this branch of `docs-general` in a local build.