### PR TITLE
@W-22472084 Exclude files from llms.txt, add example descriptions

### DIFF
--- a/antora.yml
+++ b/antora.yml
@@ -3,3 +3,6 @@ title: Home
 version: ~
 nav:
 - modules/ROOT/nav.adoc
+asciidoc:
+  attributes:
+    page-component-desc: Get started with a tutorial for building your first API, resource pages with links to other guides and websites, and a glossary.

--- a/modules/ROOT/pages/api-led-deploy-old.adoc
+++ b/modules/ROOT/pages/api-led-deploy-old.adoc
@@ -1,4 +1,5 @@
 = Step 5. Deploy the API to CloudHub
+:page-llms-exclude: true
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/api-led-design-old.adoc
+++ b/modules/ROOT/pages/api-led-design-old.adoc
@@ -1,4 +1,5 @@
 = Step 2. Design an API Specification
+:page-llms-exclude: true
 
 To design an API, assess the purpose and requirements:
 

--- a/modules/ROOT/pages/api-led-develop-old.adoc
+++ b/modules/ROOT/pages/api-led-develop-old.adoc
@@ -1,4 +1,5 @@
 = Step 3. Develop the API 
+:page-llms-exclude: true
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/api-led-operate-old.adoc
+++ b/modules/ROOT/pages/api-led-operate-old.adoc
@@ -1,4 +1,5 @@
 = Step 6. Operate the Deployed API
+:page-llms-exclude: true
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/api-led-overview-old.adoc
+++ b/modules/ROOT/pages/api-led-overview-old.adoc
@@ -1,4 +1,5 @@
 = Tutorial: Build an API from Start to Finish
+:page-llms-exclude: true
 
 API-led connectivity enables delightful experiences on a variety of devices for your customers. Different software applications communicate and share information across different systems. An Application Programming Interface (API) acts as a digital messenger and translator between those applications and systems, ensuring you can adapt to changes, reuse solutions efficiently, and build security into the digital touchpoints of your business.
 

--- a/modules/ROOT/pages/api-led-overview.adoc
+++ b/modules/ROOT/pages/api-led-overview.adoc
@@ -1,4 +1,5 @@
 = Tutorial: Build an API from Start to Finish
+:description: Overview of a multipart tutorial for MuleSoft's API development workflow, covering how to build your first API from design to deployment using Anypoint Code Builder.
 :page-pagination: next
 
 Build your first API from design to deployment using Anypoint Code Builder. Design an API spec, implement the logic, test locally, and deploy to CloudHub 2.0 to learn the complete MuleSoft API development workflow.
@@ -15,7 +16,7 @@ A simple "Hello World" API that:
 
 * Anypoint Code Builder
 +
-Your cloud-based development environment for designing and building APIs. 
+Your cloud-based development environment for designing and building APIs.
 
 * MuleSoft Vibes (Optional)
 +
@@ -33,7 +34,7 @@ Your operations dashboard for monitoring deployed APIs, viewing logs, and managi
 
 Complete the steps in order to create your first API:
 
-. xref:api-led-prerequisites.adoc[Complete the prerequisites]. 
+. xref:api-led-prerequisites.adoc[Complete the prerequisites].
 . xref:api-led-design.adoc[Design an API spec with AI].
 . xref:api-led-develop.adoc[Scaffold and implement the API].
 . xref:api-led-test.adoc[Test your API locally].

--- a/modules/ROOT/pages/api-led-prerequisites-old.adoc
+++ b/modules/ROOT/pages/api-led-prerequisites-old.adoc
@@ -1,4 +1,5 @@
 = Step 1. Prerequisites for Building an API
+:page-llms-exclude: true
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/api-led-test-old.adoc
+++ b/modules/ROOT/pages/api-led-test-old.adoc
@@ -1,4 +1,5 @@
 = Step 4. Add Validation and Error Handling
+:page-llms-exclude: true
 ifndef::env-site,env-github[]
 include::_attributes.adoc[]
 endif::[]

--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -1,4 +1,5 @@
 = [.brand]#MuleSoft# Documentation
+:page-llms-exclude: true
 :page-layout: home
 :page-fragmentize:
 :!sectids:


### PR DESCRIPTION
Making changes in this repo for our llms.txt files to demonstrate how to:

* Exclude files from our llms.txt file, for example when topics are stubs without much content. I noticed that we're also publishing the old version of the tutorial even though it's not included in our TOC, so I'm excluding those files as well.
* Add guide- (component-) level descriptions that show up in the top-level [llms.txt](https://docs.mulesoft.com/llms.txt) file.  By default we get these descriptions from the first line of the overview topic. For this repo there isn't a usable first line, so I temporarily had an override in place in our docs-site-playbook. I'm now moving that into this repo as IMO the descriptions should go with the content.
* Add topic-level descriptions to child llms.txt files. For example, here's the [child llms.txt file](https://docs.mulesoft.com/general/llms.txt) for docs-general. As a bonus, these descriptions will also show up in our meta description tags for SEO.

Will follow up with some wiki documentation and send out to the team.