### PR TITLE
W-22710322 Update usage-reports to differentiate vCore ELA and flow-based pricing customers

### DIFF
--- a/modules/ROOT/pages/usage-reports.adoc
+++ b/modules/ROOT/pages/usage-reports.adoc
@@ -11,7 +11,12 @@ All reports are calculated using the UTC time standard. For example, a daily usa
 
 Daily usage retention is three months and monthly usage retention is up to five years.
 
-Organizations that have a usage-based pricing model can compare actual usage from the report against the existing contract. However, usage reports are not for billing purposes. For more information about usage metrics and pricing, read xref:pricing.adoc[] and xref:usage-metrics.adoc[]
+Usage reports support different customer types:
+
+* vCore ELA customers: Monitor combined vCore consumption across CloudHub and CloudHub 2.0, including usage from horizontal pod autoscaling (HPA). Your contracted vCore allotment governs your renewal.
+* Usage-based pricing customers (Anypoint Integration Advanced, Platinum, or Titanium): Compare actual usage from the report against the existing contract to avoid overages.
+
+Usage reports are not for billing purposes. For more information about usage metrics and pricing, read xref:pricing.adoc[] and xref:usage-metrics.adoc[]
 
 Some usage data, such as monthly statements and vCore allocation, appears in different areas of Anypoint Platform or Salesforce products. 
 

--- a/modules/ROOT/pages/usage-reports.adoc
+++ b/modules/ROOT/pages/usage-reports.adoc
@@ -13,7 +13,7 @@ Daily usage retention is three months and monthly usage retention is up to five 
 
 Usage reports support different customer types:
 
-* vCore ELA customers: Monitor combined vCore consumption across CloudHub and CloudHub 2.0, including usage from horizontal pod autoscaling (HPA). Your contracted vCore allotment governs your renewal.
+* vCore customers: Monitor combined vCore consumption across CloudHub and CloudHub 2.0. Your contracted vCore allotment governs your renewal.
 * Usage-based pricing customers (Anypoint Integration Advanced, Platinum, or Titanium): Compare actual usage from the report against the existing contract to avoid overages.
 
 Usage reports are not for billing purposes. For more information about usage metrics and pricing, read xref:pricing.adoc[] and xref:usage-metrics.adoc[]


### PR DESCRIPTION
## Summary

- Adds customer-type-specific guidance to the Usage Reports intro, mirroring the billing clarifications made in docs-hosting PR #433 (HPA docs update)
- vCore ELA customers: directed to monitor combined CloudHub + CloudHub 2.0 vCore consumption, including HPA-driven usage; renewal governed by contracted vCore allotment
- Flow-based pricing customers (Anypoint Integration Advanced, Platinum, or Titanium): directed to compare usage against contract to avoid overages

## Test plan

- [ ] Verify rendered output matches intent — two bullet list with customer-type guidance
- [ ] Confirm xrefs to `pricing.adoc` and `usage-metrics.adoc` still resolve