### PR TITLE
W-23480092 docs: document Akamai security integration in exp-governan…

### DIFF
--- a/modules/ROOT/pages/exp-governance-manage-strategies.adoc
+++ b/modules/ROOT/pages/exp-governance-manage-strategies.adoc
@@ -5,7 +5,7 @@ Keep governance strategies aligned with your portfolio by adjusting scope, rules
 
 == Display Governance Strategies
 
-Go to *Governance* > *Governance Strategies* to view all strategies. Check the name, type, status, governed services, and last modified time.
+Go to *Governance* > *Governance Strategies* to view all strategies. Check the strategy name, type, environment, target, status, governed services count, and last modified time.
 
 == Available Strategy Actions
 
@@ -15,11 +15,15 @@ Go to *Governance* > *Governance Strategies* to view all strategies. Check the n
 * Reorder strategies: Change strategy order when multiple strategies govern the same services.
 * Delete a strategy: Permanently remove a strategy that you no longer need.
 
+== View Strategy Details
+
+When you open a strategy, the *Governed Services* tab lists each service in scope with its conformance status. When Akamai API Security is enabled, a *Security Risk* column also appears showing the per-service risk level: *Critical*, *High*, *Medium*, or *Low*.
+
 == Filter and Search Strategies
 
 Use the controls above the table to narrow the list:
 
-* Use the strategy type filter to select *All*, *Controls*, or *Automated Policies*.
+* Use the strategy type tabs to show *All*, *Controls*, or *Automated Policies*.
 * Use the status filter to select *Any Status*, *Active*, or *Disabled*.
 * Enter text in the search field to match strategy names.
 
@@ -34,6 +38,10 @@ Review the summary cards:
 * *Governance Coverage*: When available, the portion of the portfolio governed by at least one strategy
 
 Use these cards to spot governance gaps quickly.
+
+== Akamai-Generated Strategy
+
+When you connect Akamai API Security as a provider, the system automatically creates a pre-configured Akamai security strategy in the strategy list. This strategy attributes Akamai security findings to your MuleSoft APIs and MCP servers. Do not delete it unless you also remove the Akamai scanner, because deleting the strategy stops security findings from appearing in conformance reports.
 
 == When to Adjust a Strategy
 

--- a/modules/ROOT/pages/exp-governance-work-with-strategies.adoc
+++ b/modules/ROOT/pages/exp-governance-work-with-strategies.adoc
@@ -38,6 +38,38 @@ Work with your governance lead when strategy changes affect production or compli
 * Review conformance reporting for xref:exp-overview.adoc[supported catalog types].
 * Apply policies to services from *Portfolio*. See xref:exp-services-view-details.adoc[].
 
+== Akamai Security Findings in Conformance Reports
+
+When Akamai API Security is connected as a provider, the *Violations*, *Warnings*, and *Info* counts in the conformance report include Akamai security findings alongside governance rule results. A service can show a *Non-Conformant* status even when no governance rules are violated, if Akamai findings contribute violations.
+
+The Conformance tab includes a dedicated Akamai section with two tables:
+
+* *Security Findings*: Individual security issues detected by Akamai through live traffic inspection, broken down per instance and per endpoint.
+* *Incidents*: Recurring threats aggregated over time, with first- and last-seen timestamps and occurrence counts.
+
+Both tables have the following columns, each sortable: *Finding*, *Instance*, *Endpoint*, and *Risk*.
+
+Akamai severity levels map to conformance tiers as follows:
+
+* Critical and High map to violations.
+* Medium maps to warnings.
+* Low and Info map to informational findings.
+
+The *Severity* filter at the top of the Conformance tab applies to both the governance rule results and the Akamai tables.
+
+=== Review a Finding
+
+Select a row in the *Security Findings* table to open the finding detail panel, which shows:
+
+* *Triggered On*: The endpoint path where the issue was detected.
+* *Risk*: The severity level.
+* *Exposure*: Whether the endpoint is internet-facing.
+* *Remediation Opportunities*: Curated recommended policies for this finding type. Select *Apply This Policy* to open the policy-apply flow with the policy pre-selected. Select *Browse in Policy Library* if no curated policy is listed. After a policy is applied, Akamai re-inspects live traffic and updates the finding status automatically.
+
+=== Review an Incident
+
+Select a row in the *Incidents* table to open the incident detail panel, which shows: *Detection Time*, *Type*, *Triggered On*, *Severity*, *Occurrences*, *Exposure*, OWASP tags, and Compliance Frameworks.
+
 == See Also
 
 * xref:exp-governance-create-strategy.adoc[]


### PR DESCRIPTION
…ce- topics

- exp-governance-manage-strategies: fix column list, change filter description from dropdown to tabs, add View Strategy Details section for Governed Services tab + Security Risk column, add Akamai-Generated Strategy section
- exp-governance-work-with-strategies: add Akamai Security Findings in Conformance Reports section covering KPI impact, Security Findings and Incidents tables, severity-to-tier mapping, finding and incident detail panels, and remediation workflow