### PR TITLE
Address PR review comments for Model Proxy documentation

### DIFF
--- a/modules/ROOT/pages/model-proxy-create-model-proxy.adoc
+++ b/modules/ROOT/pages/model-proxy-create-model-proxy.adoc
@@ -26,13 +26,13 @@ For more information, see xref:exp-home-start.adoc#permissions[Enhanced Experien
 +
 See xref:gateway::flex-gateway-managed-set-up.adoc[].
 * API keys to authenticate with your LLM Providers.
-. xref:model-proxy-semantic-service.adoc[Configured a semantic service] if you want to use semantic routing.
+* A xref:model-proxy-semantic-service.adoc[configured semantic service] if you want to use semantic routing.
 
 [[create-a-model-proxy]]
 == Create a Model Proxy
 
 . In the navigation pane, select *Model Proxies*.
-. Click *Add Model Proxy*.
+. Click *Add Model Proxy*
 . Configure the proxy parameters:
 .. *Proxy Name*: Define a name for the Model Proxy.
 .. *Description*: Provide a description of what this proxy does.
@@ -45,7 +45,7 @@ See xref:gateway::flex-gateway-managed-set-up.adoc[].
 .. *Environment*: Select the environment for the Model Proxy.
 .. *Omni Gateway*: Select an Omni Gateway to deploy the Model Proxy to.
 .. *Consumer Endpoint*: Specify the URL where the Model Proxy will be accessible.
-.. *Port*: Enter the port number for the Model Proxy (for example: `8081`).
+.. *Port*: Enter the port number for the Model Proxy (for example, `8081`).
 . Click *Continue*.
 . Configure the routing strategy:
 .. *Routing strategy*: Select a routing strategy:
@@ -53,8 +53,8 @@ See xref:gateway::flex-gateway-managed-set-up.adoc[].
 *** *Model-based*: Route requests based on the model specified in the request payload.
 *** *Semantic*: Route requests based on semantic analysis of the prompt content. Requires a configured semantic service.
 . Configure at least one route:
-.. Provide a route name (for example, `Route A`).
-.. Optionally, click *Add headers* to add routing headers that filter requests by region, SLA, or custom rules. For example, `Region: US`.
+.. Provide a route name (for example, `Route A`)
+.. Optionally, click *Add headers* to add routing headers that filter requests by region, SLA, or custom rules. For example, `Region: US`
 .. Configure the target:
 *** *Provider*: Select your LLM provider from these options:
 **** *OpenAI*
@@ -66,95 +66,11 @@ See xref:gateway::flex-gateway-managed-set-up.adoc[].
 *** *Model*: Select a target model to override the model version specified in the payload. Selecting *Not Applicable* sends the request to the model specified in the request. A target model is required for semantic routing.
 .. Configure authentication:
 *** *Destination URL*: Specify the URL for your provider endpoint. Ensure the URL is correct and edit if necessary.
-*** *API Key*: Select either:
-**** *Static*: Enter a static API key for the provider endpoint.
-**** *Dynamic*: Define a DataWeave script to extract the API key from the incoming request.
-. Click *Add Route* to add additional routes. Complete the previous steps to configure each new route.
+*** *API Key*: Choose one of the following:
+**** *Static*: Enter a static API key for the provider endpoint
+**** *Dynamic*: Define a DataWeave script to extract the API key from the incoming request
+. Click *Add Route* to add additional routes. Complete the previous steps to configure each new route
 . Click *Add Model Proxy*.
-
------------------------
-
-
-. From API Manager, click *Model Proxies*.
-. Click *+ Add Model Proxy*.
-. Configure the *Inbound Endpoint* of the Model Proxy:
-.. Define a *Model Proxy Name*.
-.. Select an endpoint *Format*:
-+
-** *OpenAI*: Select the OpenAI API format to send requests to all supported LLM Providers (including Gemini and Anthropic). Supports multi-routing and fallback mechanisms. You can't change this format later.
-** *Gemini*: Select the Gemini API format for native Google Gemini model requests. Doesn't support multi-routing or fallback mechanisms. You can't change this format later.
-** *Anthropic*: Select the Anthropic API format for native Anthropic Claude model requests. Doesn't support multi-routing or fallback mechanisms. You can't change this format later.
-.. Define a *Base path*.
-.. Select *Advanced options* if necessary.
-.. Click *Next*.
-. Select an Omni Gateway to deploy the server instance to from *Select a gateway*.
-. Configure the routes that comprise the *Outbound Endpoint*:
-.. Select your *LLM Provider*.
-.. Ensure the *URL* for your provider is correct. Edit if necessary.
-.. Configure access details for the provider endpoint.
-.. Select a *Static* or *Dynamic* API Key. If selecting *Dynamic* API Key, define a DataWeave script to extract the API Key from the incoming request.
-.. Select a *Target Model* to override the model version specified in the payload. Selecting *Not Applicable* sends the request to the specified model. A *Target Model* is required for semantic routing.
-+
-[NOTE]
-====
-To configure a target model for Amazon Bedrock Claude Modes, you must enter the provider and model ID formatted as `[provider_prefix]/[internal_model_id]`.
-
-To learn how to find the model ID, see xref:model-proxy-request.adoc#amazon-bedrock-model-names[Amazon Bedrock Model Names].
-====
-
-.. Click *Add LLM Route* to add additional routes. Complete the previous steps to configure the new route. Each LLM Provider supports one route.
-. If adding multiple routes, select a *Routing strategy*. To configure your routing strategy, see:
-.. <<configure-model-based-routing>>
-.. <<configure-semantic-routing>>
-. 
-. Click *Save & Deploy*.
-
-[[configure-model-based-routing]]
-== Configure Model-Based Routing
-
-. Configure multiple routes. Click *Add LLM Route* to create new routes.
-. Select *Model-based* for *Routing strategy*.
-. Choose to enable a *Fallback route* for the request to be sent to if the provider or model is incorrectly sepcified. If enabling a fallback route:
-.. Select a *Route* to fallback to.
-.. Select a target model for the fallback route to use.
-. If no fall back route is configured and a route fails, a error response is returned.
-. Return to <<create-a-model-proxy>> step 7 to finish configuring your Model Proxy.
-
-[[configure-semantic-routing]]
-== Configure Semantic Routing
-
-To configure semantic routing:
-
-. Make sure you have already xref:model-proxy-semantic-service.adoc[Configured a semantic service].
-. Configure multiple routes and select a target model for each route. Click *Add LLM Route* to create new routes.
-. Select *Semantic* for *Routing strategy*.
-. Click *Select a service* and select a service.
-. Define or select a prompt topic for the routes:
-** Advanced scale semantic service:
-... Select prompt topics from your predefined prompt topics.
-** Basic scale semantic service:
-... Click the *Select prompt topics*.
-... Click *+ Create prompt topic*.
-... Define a *Prompt topic name*.
-... Define a *Prompt utterances* or click *Upload utterances* to upload a plain text file containing your prompt utterances.
-... Click *Create*.
-... Create multiple prompt topics for each route as needed.
-. Configure a *Fallback route* for the request to be sent to if it doesn't match a semantic route:
-.. Specify an accuracy threshold. When the accuracy of the semantic match is less than this threshold, traffic is sent to the fallback route.
-.. Select a *Route* to fallback to.
-.. Select a *Target model* for the fallback route to use.
-. Create a *Semantic prompt guard* to block users from asking the server about specific topics:
-** Advanced scale semantic service:
-... Select topics from your predefined prompt topics.
-** Basic scale semantic service:
-... Click *+ Create deny list*.
-... Define a *Prompt topic name*.
-... Define prompt utterances or click *Upload utterances* to upload a plain text file containing your prompt utterances.
-... Click *Create*.
-... Create multiple prompt topics for each route as needed.
-+
-NOTE: Creating a semantic prompt guard automatically applies the Semantic Prompt Guard policy.
-. Return to <<create-a-model-proxy>> step 7 to finish configuring your Model Proxy.
 
 == Edit and Delete a Model Proxy
 

--- a/modules/ROOT/pages/model-proxy-request.adoc
+++ b/modules/ROOT/pages/model-proxy-request.adoc
@@ -48,7 +48,7 @@ All requests are designed to work for both strategies. When sending a request to
 +
 NOTE: Adding a model to a request ensures deterministic routing to a preferred backend if the routing strategy of a Model Proxy changes.
 
-=== Chat Completions API Validation Request Examples
+=== Chat Completions API Validation /chat/completions Request Examples
 
 https://developers.openai.com/api/reference/resources/chat[Chat Completions] is the standard API for interacting with models. It is designed for conversational multi-turn interactions rather than simple text continuation. The endpoint requires a model and a messages list with roles (such as system, user, or assistant) to generate context-aware responses.
 
@@ -96,7 +96,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-==== Creative Content Generation Example
+==== Creative Content Generation Temperature Control Example
 
 This request example performs can preform brainstorming tasks, such as generating multiple unique marketing slogans. The example writes creative content using the temperature parameter (0 to 2 value, higher values are more creative) to control the randomness and creativity of the response:
 
@@ -180,7 +180,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-==== Structured Data Validation Example
+==== Structured Data Validation JSON Format Example
 
 This request example extracts patterns into structured JSON to transform a messy transcript into a clean JSON object for insertion into a database by using the `top_p` and `max_completion_tokens` parameters:
 
@@ -485,7 +485,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-==== Structured Output Validation Example
+==== Structured Output Validation JSON Schema Example
 
 This request example validates entity extraction into a strictly defined JSON Schema (CalendarEvent). The example asks the model to extract the event information from a plain text user query and return a formatted JSON object that adheres to the required schema. This prevents integration or parsing errors in downstream applications:
 
@@ -555,7 +555,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-=== Responses API Validation
+=== Responses API Validation /responses
 
 https://developers.openai.com/api/reference/resources/responses[OpenAI Responses API] is recommended unified interface for building powerful, agent-like applications, combining capabilities from previous APIs (like Chat Completions and Assistants) into a single, more efficient endpoint. It is designed to be stateful by default and offers built-in access to advanced tools.
 

--- a/modules/ROOT/pages/model-proxy-request.adoc
+++ b/modules/ROOT/pages/model-proxy-request.adoc
@@ -22,10 +22,10 @@ To find your Model Proxy endpoint configuration and client application credentia
 .. Copy the *Public Endpoint*.
 . Find your base path:
 .. From the enhanced experience, select *Model Proxies*.
-. Click the name of the Model Proxy whose base path you want to find.
+.. Click the name of the Model Proxy whose base path you want to find.
 .. From *Configuration*, copy the *Base path*.
 . Retrieve your client ID and client secret:
-.. From the *Overview* page of your Model Proxy, click *Actions* > *View Model proxy in Exchange*.
+.. From the *Overview* page of your Model Proxy, click *Actions* > *View Model Proxy in Exchange*.
 .. Click *Request access*.
 .. Select the *API Instance* you want to request access to.
 .. Select the *Application* you want to request access to.
@@ -36,19 +36,19 @@ To find your Model Proxy endpoint configuration and client application credentia
 [[openai-format]]
 == OpenAI Format
 
-To learn more about the OpenAI request types:
+Learn more about the OpenAI request types:
 
 * https://developers.openai.com/api/reference/resources/chat[Chat Completions] API is designed for conversational multi-turn interactions rather than simple text continuation.
 * https://developers.openai.com/api/reference/resources/responses[Responses] API is recommended unified interface for building powerful agent-like applications.
 
-All requests in this guide are designed to work for both strategies. When sending a request to a Model Proxy with either routing strategy, you can specify a model in the request. You don't have to modify the request for different routing strategies. Each routing strategy handles the model selection differently:
+All requests are designed to work for both strategies. When sending a request to a Model Proxy with either routing strategy, you can specify a model in the request. You don't have to modify the request for different routing strategies. Each routing strategy handles the model selection differently:
 
 * *Model-Based Routing*: The user specifies a model in the request (`"model": "openai/gpt-5.2"`). The Model Proxy acts as a direct proxy. If no model is specified, the Model Proxy sends the request to the fallback route or returns an error if no fallback route is configured.
 * *Semantic Routing*: No model is specified in the request. The Model Proxy chooses which model to use based on the request content by matching it to prompt topics you define for each route. If a model is specified in the request, like in model routing examples, it is ignored.
 +
 NOTE: Adding a model to a request ensures deterministic routing to a preferred backend if the routing strategy of a Model Proxy changes.
 
-=== Chat Completions API Validation (/chat/completions) Request Examples
+=== Chat Completions API Validation Request Examples
 
 https://developers.openai.com/api/reference/resources/chat[Chat Completions] is the standard API for interacting with models. It is designed for conversational multi-turn interactions rather than simple text continuation. The endpoint requires a model and a messages list with roles (such as system, user, or assistant) to generate context-aware responses.
 
@@ -96,7 +96,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-==== Creative Content Generation (Temperature Control) Example
+==== Creative Content Generation Example
 
 This request example performs can preform brainstorming tasks, such as generating multiple unique marketing slogans. The example writes creative content using the temperature parameter (0 to 2 value, higher values are more creative) to control the randomness and creativity of the response:
 
@@ -180,7 +180,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-==== Structured Data Validation (JSON Format) Example
+==== Structured Data Validation Example
 
 This request example extracts patterns into structured JSON to transform a messy transcript into a clean JSON object for insertion into a database by using the `top_p` and `max_completion_tokens` parameters:
 
@@ -268,7 +268,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 
 ==== Streaming API Call Example
 
-This example is designed for User-facing chatbot UIs where the text must appear word-by-word as it is generated, rather than waiting for the entire response to finish. This request example validates the gateway's ability to stream real-time non-buffered token delivery using the `--no-buffer` flag:
+This example supports user-facing chatbot UIs where the text must appear word-by-word as it is generated, rather than waiting for the entire response to finish. This request example validates the gateway's ability to stream real-time non-buffered token delivery using the `--no-buffer` flag:
 
 [tabs]
 ====
@@ -485,7 +485,7 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-==== Structured Output Validation (JSON Schema) Example
+==== Structured Output Validation Example
 
 This request example validates entity extraction into a strictly defined JSON Schema (CalendarEvent). The example asks the model to extract the event information from a plain text user query and return a formatted JSON object that adheres to the required schema. This prevents integration or parsing errors in downstream applications:
 
@@ -555,11 +555,11 @@ curl --location '<public-endpoint>/<base-path>/chat/completions' \
 ----
 ====
 
-=== Responses API Validation (/responses)
+=== Responses API Validation
 
 https://developers.openai.com/api/reference/resources/responses[OpenAI Responses API] is recommended unified interface for building powerful, agent-like applications, combining capabilities from previous APIs (like Chat Completions and Assistants) into a single, more efficient endpoint. It is designed to be stateful by default and offers built-in access to advanced tools.
 
-==== Responses Endpoint for MCP (Model Context Protocol)
+==== Responses Endpoint for Model Context Protocol (MCP)
 
 This request example integrates the gateway with an external MCP server for automated action execution. The example asks an AI agent to search a specific internal Knowledge Base or update a Jira ticket using standardized tools defined on a remote MCP server:
 
@@ -720,7 +720,7 @@ curl --location '<public-endpoint>/<base-path>/models/gemini-2.5-flash:generateC
 
 === Streaming API Call Example
 
-This example is designed for user-facing chatbot UIs where the text must appear word-by-word as it is generated rather than waiting for the entire response to finish. This request example validates the gateway's ability to stream real-time, non-buffered token delivery:
+This example supports user-facing chatbot UIs where the text must appear word-by-word as it is generated rather than waiting for the entire response to finish. This request example validates the gateway's ability to stream real-time, non-buffered token delivery:
 
 [source,cli]
 ----


### PR DESCRIPTION
- Fix bullet list inconsistency in prerequisites
- Remove punctuation from UI element references per style guide
- Fix inconsistent colon usage in examples
- Remove parentheticals from section headings
- Change "is designed for" to "supports" for more direct language
- Remove self-referential language ("this guide")
- Remove duplicate/leftover content sections
- Fix numbered list nesting issue
- Capitalize "Model Proxy" consistently in UI references
- Move MCP initialism expansion to heading