### PR TITLE
W-23817598 Add F5 Guardrails Policy to Model Proxy policies

### DIFF
--- a/modules/ROOT/pages/model-proxy-policies.adoc
+++ b/modules/ROOT/pages/model-proxy-policies.adoc
@@ -23,6 +23,7 @@ These policies are specific and useful for Model Proxies:
 
 * xref:gateway::policies-included-bedrock-guardrails.adoc[]
 * xref:gateway::policies-included-azure-content-safety.adoc[]
+* xref:gateway::policies-included-f5-guardrails.adoc[]
 * xref:gateway::policies-included-llm-pii-detection.adoc[]
 * xref:gateway::policies-included-llm-token-rate-limit.adoc[]
 * xref:gateway::policies-included-regex-prompt-guard.adoc[]


### PR DESCRIPTION
## Summary

Links the new **F5 Guardrails Policy** from the Model Proxy policies page, alongside the other content-safety / LLM policies (Azure Content Safety, Amazon Bedrock Guardrails, etc.).

## Changes

- `model-proxy-policies.adoc` — added an xref to `gateway::policies-included-f5-guardrails.adoc` in the list of policies specific and useful for Model Proxies.

## Related

- Policy documentation: `mulesoft/docs-gateway` PR #1147 (companion, adds the F5 Guardrails Policy page the xref targets).
- Release note: `mulesoft-emu/docs-release-notes` branch `W-23817598-f5-guardrail-policy-gr`.
- Policy source: microgateway-hybrid-policies PR #657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
