### PR TITLE
W-24075721: Add EU Control Plane to the documentation archive index

### DIFF
--- a/modules/ROOT/pages/index.adoc
+++ b/modules/ROOT/pages/index.adoc
@@ -107,6 +107,9 @@ s| Salesforce OMS  |
 | Design Center | |
   xref:design-center::index.adoc[Flow Designer Archive]
 
+| EU Control Plane | |
+  xref:eu-control-plane::index.adoc[Archive]
+
 | Flex Gateway | |
   xref:1.11@gateway::index.adoc[v1.11 Archive] +
   xref:1.10@gateway::index.adoc[v1.10 Archive] +


### PR DESCRIPTION
## Summary
- W-24075721
- Adds EU Control Plane to the archive site index at https://archive.docs.mulesoft.com/general/
- Links to the archived `eu-control-plane` component (`docs-eu-cloud`)

Replaces #571, which GitHub auto-closed when the head branch was renamed.

## Test plan
- [ ] Confirm the EU Control Plane row appears between Design Center and Flex Gateway on the archive index
- [ ] After the archive playbook PR is merged and an archive site build is requested, confirm https://archive.docs.mulesoft.com/eu-control-plane/ resolves